### PR TITLE
feat: Make download server public by default in example config

### DIFF
--- a/install.config.example
+++ b/install.config.example
@@ -30,7 +30,7 @@ JWT_SECRET=1234
 ##################################################
 
 API_PORT=5029
-API_HOST=127.0.0.1
+API_HOST=0.0.0.0
 API_HOMEPAGE=https://craig.chat/
 ENNUIZEL_BASE=https://ez.craig.horse/
 TRUST_PROXY=


### PR DESCRIPTION
The `install.config.example` now sets `API_HOST=0.0.0.0` for the download server ("rec" part). This guides you when self-hosting the application to have the download server listen on all network interfaces by default, making it publicly accessible.

The application code itself (in `apps/download/api/src/api.ts`) still defaults to 'localhost' if API_HOST is not set, but this change makes the recommended example configuration public-facing.